### PR TITLE
Add support for DE440.bsp

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -29,6 +29,7 @@ jobs:
         working-directory: ./data/
         run: |
           #wget --no-verbose https://ssd.jpl.nasa.gov/ftp/eph/planets/Linux/de441/linux_m13000p17000.441  
+          wget --no-verbose https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/de440.bsp
           wget --no-verbose https://ssd.jpl.nasa.gov/ftp/eph/planets/Linux/de440/linux_p1550p2650.440
           wget --no-verbose https://ssd.jpl.nasa.gov/ftp/eph/small_bodies/asteroids_de441/sb441-n16.bsp
       - name: Reproduce Holman trajectory
@@ -88,6 +89,41 @@ jobs:
           LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
       - name: Run benchmark
         working-directory: ./unit_tests/benchmark
+        run: |
+          make
+          LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
+      - name: Compare Linux Binary and BSP DE440 Ephem
+        working-directory: ./unit_tests/de440_compare_ephem/
+        run: |
+          make
+          LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
+      - name: Compare Linux Binary and BSP DE440 Constants
+        working-directory: ./unit_tests/de440_compare_constants/
+        run: |
+          make
+          LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
+      - name: Test Loading Spice Kernels
+        working-directory: ./unit_tests/spk_init/
+        run: |
+          make
+          LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
+      - name: Test Loading Constants from Planet SPK
+        working-directory: ./unit_tests/spk_load_constants/
+        run: |
+          make
+          LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
+      - name: Test Joining Mass Data from SPK
+        working-directory: ./unit_tests/spk_join_masses/
+        run: |
+          make
+          LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
+      - name: Reproduce Apophis Encounter with bsp 
+        working-directory: ./unit_tests/apophis_bsp/
+        run: |
+          make
+          LD_LIBRARY_PATH=../../../rebound/src/ ./rebound
+      - name: Reproduce Ceres-5303 encounter with bsp
+        working-directory: ./unit_tests/5303_Ceres_bsp/
         run: |
           make
           LD_LIBRARY_PATH=../../../rebound/src/ ./rebound

--- a/README.md
+++ b/README.md
@@ -25,18 +25,36 @@ Now we can install numpy, REBOUND, and ASSIST:
     pip install rebound 
     pip install assist
 
-To use use ASSIST, you also need to download ephemeris data files. One file for planet ephemeris and another suplementary file for asteroid ephemeris. The following commands download these files with curl. You can also manually download them using your browser. Note that these are large files, almost 1GB in size.
+To use use ASSIST, you also need to download ephemeris data files. One file for planet ephemeris and another suplementary file for asteroid ephemeris. You can do this with Python packages or by downloading files directly.  Note that these are large files, almost 1GB in size.
+
+    pip install naif-de440
+    pip install jpl-small-bodies-de441-n16
+
+
+You can initialize the ephemeris data from the packages like so:
+
+    python3
+
+    >>> import assist
+    >>> from naif_de440 import de440
+    >>> from jpl_small_bodies_de441_n16 import de441_n16
+    >>> ephem = assist.Ephem(de440, de441_n16)
+
+The variables to the ephemeris files are simply path strings to the files. Alternatively, you can download these files with curl. You can also manually download them using your browser.
 
     mkdir data
     curl https://ssd.jpl.nasa.gov/ftp/eph/planets/Linux/de440/linux_p1550p2650.440 -o data/linux_p1550p2650.440
     curl https://ssd.jpl.nasa.gov/ftp/eph/small_bodies/asteroids_de441/sb441-n16.bsp -o data/sb441-n16.bsp
 
-Now you can try out if assist works.
+Now you can point assist to those files directly, like so:
 
     python3
 
     >>> import assist
     >>> ephem = assist.Ephem("data/linux_p1550p2650.440", "data/sb441-n16.bsp")
+
+Once you've initialized the ephemeris data, you can test that assist is working by running the following commands:
+
     >>> print(ephem.jd_ref)
     >>> ephem.get_particle("Earth", 0)
 

--- a/assist/ephem.py
+++ b/assist/ephem.py
@@ -1,10 +1,13 @@
+import warnings
+from ctypes import (CFUNCTYPE, POINTER, Structure, byref, c_char, c_char_p,
+                    c_double, c_int, c_long, c_uint, c_uint32, c_ulong,
+                    c_void_p, cast)
 from typing import Optional, Union
 
-from . import clibassist, assist_error_messages
-from ctypes import Structure, c_double, POINTER, c_int, c_uint, c_long, c_ulong, c_void_p, c_char_p, CFUNCTYPE, byref, c_uint32, c_uint, cast, c_char
-import rebound
 import assist
-import warnings
+import rebound
+
+from . import assist_error_messages, clibassist
 
 ASSIST_BODY_IDS = {
         0: "Sun",
@@ -82,8 +85,11 @@ class Ephem(Structure):
     def __del__(self) -> None:
         clibassist.assist_ephem_free_pointers(byref(self))
 
-    _fields_ =  [("jd_ref", c_double),
-                 ("_pl", c_void_p),
-                 ("_spl", c_void_p),
-            ]
+    _fields_ = [
+        ("jd_ref", c_double),
+        ("jpl_planets", c_void_p),
+        ("spk_global", c_void_p),
+        ("spk_planets", c_void_p),
+        ("spk_asteroids", c_void_p),
+    ]
 

--- a/assist/extras.py
+++ b/assist/extras.py
@@ -1,12 +1,16 @@
-from typing import NoReturn, List
-
-from . import clibassist
-from ctypes import Structure, c_double, POINTER, c_int, c_uint, c_long, c_ulong, c_void_p, c_char_p, CFUNCTYPE, byref, c_uint32, c_uint, cast, c_char
-import rebound
 import warnings
-from .ephem import Ephem
+from ctypes import (CFUNCTYPE, POINTER, Structure, byref, c_char, c_char_p,
+                    c_double, c_int, c_long, c_uint, c_uint32, c_ulong,
+                    c_void_p, cast)
+from typing import List, NoReturn
+
 import numpy as np
 import numpy.typing as npt
+
+import rebound
+
+from . import clibassist
+from .ephem import Ephem
 
 ASSIST_FORCES = {
     "SUN"                : 0x01,

--- a/assist/test/test_apophis.py
+++ b/assist/test/test_apophis.py
@@ -1,8 +1,11 @@
-import rebound
-import assist
-import unittest
 import math
+import unittest
+
 import numpy as np
+
+import assist
+import rebound
+
 
 class TestAssist(unittest.TestCase):
     def test_apophis(self):

--- a/assist/test/test_basic.py
+++ b/assist/test/test_basic.py
@@ -1,7 +1,10 @@
-import rebound
-import assist
-import unittest
 import math
+import unittest
+
+import rebound
+
+import assist
+
 
 class TestAssist(unittest.TestCase):
     def test_rebound(self):
@@ -15,11 +18,11 @@ class TestAssist(unittest.TestCase):
         ephem = assist.Ephem("data/linux_p1550p2650.440", "data/sb441-n16.bsp")
         self.assertEqual(ephem.jd_ref, 2451545.0)
         p = ephem.get_particle(0,0) # Sun
-        self.assertEqual(p.x, -0.007137179161607906)
+        self.assertEqual(p.x, -0.0071371791616045835)
         p = ephem.get_particle(1,100) # planet
-        self.assertEqual(p.x, 0.12906301685045435)
+        self.assertEqual(p.x, 0.12906301685043747)
         p = ephem.get_particle(20,200) #asteroid
-        self.assertEqual(p.x, -2.62956381075119)
+        self.assertEqual(p.x, -2.629563810751188)
         del ephem
     
     def test_ephem_names(self):

--- a/src/assist.h
+++ b/src/assist.h
@@ -88,8 +88,10 @@ enum ASSIST_BODY {
 
 struct assist_ephem {
     double jd_ref;
-    struct jpl_s* jpl;
-    struct spk_s* spl;
+    struct jpl_s* jpl_planets;
+    struct spk_global* spk_global;
+    struct spk_s* spk_planets;
+    struct spk_s* spk_asteroids;
 };
 
 struct assist_cache_item {
@@ -181,6 +183,7 @@ struct reb_particle assist_get_particle_with_error(struct assist_ephem* ephem, c
 // Functions called from python:
 void assist_init(struct assist_extras* assist, struct reb_simulation* sim, struct assist_ephem* ephem);
 void assist_free_pointers(struct assist_extras* assist);
+void assist_ephem_free_pointers(struct assist_ephem* ephem);
 
 
 void test_vary(struct reb_simulation* sim, FILE *vfile);
@@ -201,5 +204,6 @@ struct assist_ephem* assist_ephem_create(char *planets_file_name, char *asteroid
  */
 ///
 int assist_ephem_init(struct assist_ephem* ephem, char *user_planets_path, char *user_asteroids_path);
-
+double assist_get_constant(struct assist_ephem* ephem, const char* name);
+double truncate_double(double value, int precision);
 #endif

--- a/src/spk.c
+++ b/src/spk.c
@@ -1,4 +1,3 @@
-
 // spk.c - code to handle spice kernel position files
 
 // https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/daf.html
@@ -9,6 +8,7 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <math.h>
+#include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -19,6 +19,15 @@
 #include "assist.h"
 #include "spk.h"
 
+
+static inline void vecpos_off(double *u, const double *v, const double w)
+        { u[0] += v[0] * w; u[1] += v[1] * w; u[2] += v[2] * w; }
+static inline void vecpos_set(double *u, const double *v)
+        { u[0] = v[0]; u[1] = v[1]; u[2] = v[2]; }
+static inline void vecpos_nul(double *u)
+        { u[0] = u[1] = u[2] = 0.0; }
+static inline void vecpos_div(double *u, double v)
+        { u[0] /= v; u[1] /= v; u[2] /= v; }
 
 
 
@@ -46,6 +55,190 @@ int assist_spk_free(struct spk_s *pl)
 	return 0;
 }
 
+/*
+ *  assist_free_spk_constants
+ *
+ */
+int assist_free_spk_constants(struct spk_global *sg) {
+
+    if (sg->masses.names) {
+        for (int i = 0; i < sg->masses.count; i++) {
+            free(sg->masses.names[i]);
+        }
+        free(sg->masses.names);
+    }
+
+    free(sg->masses.values);
+    free(sg);
+
+    return ASSIST_SUCCESS;
+}
+
+void parse_comments(int fd, int first_summary_record, char **comments) {
+    // Calculate the number of records in the comment section
+    int num_records = first_summary_record - 2;  // Number of comment records
+    if (num_records <= 0) {
+        *comments = NULL;
+        return;
+    }
+
+    // Allocate a buffer for the comments
+    int comment_length = num_records * RECORD_LENGTH;
+    char *buffer = malloc(comment_length + 1);  // +1 for null-terminator
+    if (!buffer) {
+        perror("malloc");
+        exit(EXIT_FAILURE);
+    }
+
+    // Read the comment records
+    ssize_t bytes_read;
+    size_t total_bytes_read = 0;
+    // Seek to beginning of file
+    if (lseek(fd, 0, SEEK_SET) == -1) {
+        perror("lseek");
+        free(buffer);
+        exit(EXIT_FAILURE);
+    }
+    // Read in each comment record
+    for (int i = 0; i < num_records; i++) {
+        if (lseek(fd, (1 + i) * RECORD_LENGTH, SEEK_SET) == -1) {
+            perror("lseek");
+            free(buffer);
+            exit(EXIT_FAILURE);
+        }
+        bytes_read = read(fd, buffer + total_bytes_read, RECORD_LENGTH);
+        if (bytes_read == -1) {
+            perror("read");
+            free(buffer);
+            exit(EXIT_FAILURE);
+        }
+
+        // Remove all null character and end of comment markers from the end of the buffer
+        // by deleting the bytes. These pad the ends and create extra newlines.
+        while (buffer[total_bytes_read + bytes_read - 1] == '\0' || buffer[total_bytes_read + bytes_read - 1] == '\4') {
+            bytes_read--;
+        }
+
+        total_bytes_read += bytes_read;
+    }
+
+
+    // DAF comments use the null character to indicate end of a line
+    // replace with newline character
+    for (char *p = buffer; p < buffer + total_bytes_read; p++) {
+        if (*p == '\0') {
+            *p = '\n';
+        }
+    }
+
+    // Assign the buffer to the comments pointer
+    *comments = buffer;
+
+
+}
+
+// sscanf doesn't know the 'D' scientific notation, so replace
+// it with 'E' when surrounded by digit and sign characters
+void replace_d_with_e(char *str) {
+    char *d_char = strchr(str, 'D');
+    if (d_char != NULL) {
+        // Ensure it's a scientific notation before replacing
+        if ((d_char > str && isdigit(*(d_char - 1))) && (isdigit(*(d_char + 1)) || (*(d_char + 1) == '+' || *(d_char + 1) == '-'))) {
+            *d_char = 'E';
+        }
+    }
+}
+
+
+// Reads in the constants and masses from the comments of the DE440.bsp file
+struct spk_global * assist_load_spk_constants(const char *path) {
+    // Try opening file.
+    int fd = open(path, O_RDONLY);
+    if (fd < 0){
+        return NULL;
+    }
+
+    // Load the file record
+    union record_t * record = assist_load_spk_file_record(fd);
+
+    char *comments = NULL;
+    parse_comments(fd, record->file.fward, &comments);
+
+    if (comments == NULL) {
+        printf("No comments found.\n");
+        return NULL;
+    }
+
+    struct spk_global* sg = malloc(sizeof(struct spk_global));
+    if (!sg) {
+        // Handle memory allocation failure
+        close(fd);
+        return NULL;
+    }
+
+    // Initialize the spk_global struct using designated initializers
+    *sg = (struct spk_global){
+        .con = {
+            .AU = 0,
+            .EMRAT = 0,
+            .J2E = 0,
+            .J3E = 0,
+            .J4E = 0,
+            .J2SUN = 0,
+            .RE = 0,
+            .CLIGHT = 0,
+            .ASUN = 0
+        },
+        .masses = {
+            .names = NULL,
+            .values = NULL,
+            .count = 0
+        }
+    };
+
+    char *line = strtok(comments, "\n");
+    char key[64];
+    char value_str[64];
+    double value;
+    int in_constants_section = 0;
+
+    while (line) {
+        if (strstr(line, "Initial conditions and constants used for integration:")) {
+            in_constants_section = 1;
+        }
+
+        if (in_constants_section) {
+            replace_d_with_e(line);
+            if (sscanf(line, "%63s %63s", key, value_str) == 2) {
+                // Convert the value string to double
+                value = strtod(value_str, NULL);
+                if (strcmp(key, "cau") == 0) sg->con.AU = value;
+                else if (strcmp(key, "EMRAT") == 0) sg->con.EMRAT = value;
+                else if (strcmp(key, "J2E") == 0) sg->con.J2E = value;
+                else if (strcmp(key, "J3E") == 0) sg->con.J3E = value;
+                else if (strcmp(key, "J4E") == 0) sg->con.J4E = value;
+                else if (strcmp(key, "J2SUN") == 0) sg->con.J2SUN = value;
+                else if (strcmp(key, "AU") == 0) sg->con.AU = value;
+                else if (strcmp(key, "RE") == 0) sg->con.RE = value;
+                else if (strcmp(key, "CLIGHT") == 0) sg->con.CLIGHT = value;
+                else if (strcmp(key, "ASUN") == 0) sg->con.ASUN = value;
+                else if (strncmp(key, "GM", 2) == 0 || strncmp(key, "MA", 2) == 0) {
+                    sg->masses.names = realloc(sg->masses.names, (sg->masses.count + 1) * sizeof(char *));
+                    sg->masses.values = realloc(sg->masses.values, (sg->masses.count + 1) * sizeof(double));
+                    sg->masses.names[sg->masses.count] = strdup(key);
+                    sg->masses.values[sg->masses.count] = value;
+                    sg->masses.count++;
+                }
+            }
+        }
+
+        line = strtok(NULL, "\n");
+    }
+
+    free(comments);
+    close(fd);
+    return sg;
+}
 
 /*
  *  assist_spk_init
@@ -56,74 +249,148 @@ int assist_spk_free(struct spk_s *pl)
 static double inline _jul(double eph)
 	{ return 2451545.0 + eph / 86400.0; }
 
+// Populate mass data for spk targets from the global masses array
+void assist_spk_join_masses(struct spk_s *sp, struct spk_global *sg) {
+    if (sp == NULL || sg == NULL) {
+        return;
+    }
 
-#define record_length 1024
-
-struct spk_s * assist_spk_init(const char *path) {
-    // For file format information, see https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/daf.html
-
-    // Format for one summary
-    struct sum_s {
-        double beg;		// begin epoch, seconds since J2000.0
-        double end;		// ending epoch
-        int tar;		// target code
-        int cen;		// centre code (10 = sun)
-        int ref;		// reference frame (1 = J2000.0)
-        int ver;		// type of ephemeris (2 = chebyshev)
-        int one;		// initial array address
-        int two;		// final array address
+    // Create an array based mapping of the GMX and target code formats
+    struct {
+        const char *name;
+        int code;
+    } planet_codes[] = {
+        {"GMS", 10}, // Sun
+        {"GM1", 1}, // Mercury
+        {"GM2", 2}, // Venus
+        {"GMB", 399}, // Earth
+        {"GMB", 3}, // Earth-Moon Barycenter
+        {"GMB", 301}, // Moon
+        {"GM4", 4}, // Mars
+        {"GM5", 5}, // Jupiter
+        {"GM6", 6}, // Saturn
+        {"GM7", 7}, // Uranus
+        {"GM8", 8}, // Neptune
+        {"GM9", 9} // Pluto
     };
 
-    // File is split into records. We read one record at a time.
-    union {
-	    char buf[record_length];
-        struct {
-            double next;    // The record number of the next summary record in the file. Zero if this is the final summary record.
-            double prev;    // The record number of the previous summary record in the file. Zero if this is the initial summary record.
-            double nsum;    // Number of summaries in this record
-            struct sum_s s[25]; // Summaries (25 is the maximum)
-        } summary;          // Summary record
-        // See: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/daf.html#The%20File%20Record
-        struct {
-            char locidw[8]; // An identification word
-            int nd;         // The number of double precision components in each array summary.
-            int ni;         // The number of integer components in each array summary.
-            char locifn[60];// The internal name or description of the array file.
-            int fward;      // The record number of the initial summary record in the file.
-            int bward;      // The record number of the final summary record in the file.
-        } file;             // File record
-    } record;
+    // Join the mass data by iterating through the targets
+    for (int m = 0; m < sp->num; m++) {
+        // Determine the label we are matching for in the masses array
+        // If it is a planet, use the lookup value from planet_codes
+        // If it is an asteroid, we format it as "MA" + code
+        // Allocate the label and make sure it starts as a null string
+        char *mass_label = calloc(64, sizeof(char));
 
-    // Try opening file.
-	int fd = open(path, O_RDONLY);
-	if (fd < 0){
+        for (int i = 0; i < sizeof(planet_codes) / sizeof(planet_codes[0]); i++) {
+            if (sp->targets[m].code == planet_codes[i].code) {
+                strncpy(mass_label, planet_codes[i].name, 63);
+                mass_label[63] = '\0'; // Ensure null termination
+                break;
+            }
+        }
+        // If mass label is still empty, it is an asteroid
+        if (strlen(mass_label) == 0) {
+            // Format the asteroid code to be MAdddd where dddd is 4 digit
+            // 0 masked target code - 2000000
+            sprintf(mass_label, "MA%04d", sp->targets[m].code - 2000000);
+        }
+
+        // Find the mass in the masses array
+        for (int i = 0; i < sg->masses.count; i++) {
+            if (strcmp(sg->masses.names[i], mass_label) == 0) {
+                // Earth and moon mass is stored as one value
+                // Use the ratio to split it using pl->con.EMRAT
+                if (sp->targets[m].code == 399) {
+                    sp->targets[m].mass = sg->masses.values[i] * (sg->con.EMRAT / (1. + sg->con.EMRAT));
+                } else if (sp->targets[m].code == 301) {
+                    sp->targets[m].mass = sg->masses.values[i] * (1./(1.+sg->con.EMRAT));
+                } else {
+                    sp->targets[m].mass = sg->masses.values[i];
+                }
+                break;
+            }
+        }
+
+        if (sp->targets[m].mass == 0 && sp->targets[m].code != 199 && sp->targets[m].code != 299) {
+            printf("Mass not found for target code: %d\n", sp->targets[m].code);
+        }
+    }
+}
+
+// Load the file record of an spk file
+    // For file format information, see https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/daf.html
+union record_t * assist_load_spk_file_record(int fd) {
+    // Allocate memory for the record
+    union record_t *record = calloc(1, sizeof(union record_t));
+    if (!record) {
+        fprintf(stderr, "Memory allocation failed.\n");
+        close(fd);
+        return NULL;
+    }
+
+    // Seek to the beginning of the file
+    if (lseek(fd, 0, SEEK_SET) == -1) {
+        perror("lseek");
+        free(record);
+        close(fd);
+        return NULL;
+    }
+
+    // Read the file record
+    ssize_t bytesRead = read(fd, record, RECORD_LENGTH);
+    if (bytesRead != RECORD_LENGTH) {
+        if (bytesRead == -1) {
+            perror("read");
+        } else {
+            fprintf(stderr, "Incomplete read. Expected %d bytes, got %zd bytes.\n", RECORD_LENGTH, bytesRead);
+        }
+        free(record);
+        close(fd);
 		return NULL;
     }
 
-	// Read the file record. 
-    read(fd, &record, record_length);
     // Check if the file is a valid Double Precision Array File
-	if (strncmp(record.file.locidw, "DAF/SPK", 7) != 0) {
+    if (strncmp(record->file.locidw, "DAF/SPK", 7) != 0) {
         fprintf(stderr,"Error parsing DAF/SPK file. Incorrect header.\n");
+        free(record);
 		close(fd);
 		return NULL;
 	}
 
-    // Check that the size of a summary record is equal to the size of our struct.
-	int nc = 8 * ( record.file.nd + (record.file.ni + 1) / 2 );
+    // Check that the size of a summary record is equal to the size of our struct
+    int nc = 8 * (record->file.nd + (record->file.ni + 1) / 2);
 	if (nc != sizeof(struct sum_s)) {
         fprintf(stderr,"Error parsing DAF/SPK file. Wrong size of summary record.\n");
+        free(record);
 		close(fd);
 		return NULL;
 	}
     
+    return record;
+}
+
+
+// Initialize the targets of a single spk file
+// Note that target masses will not be populated until assist_spk_join_masses
+// is called.
+struct spk_s * assist_spk_init(const char *path) {
+    // Try opening file.
+    int fd = open(path, O_RDONLY);
+    if (fd < 0){
+        return NULL;
+    }
+
+    // Load the file record
+    union record_t * record = assist_load_spk_file_record(fd);
+
     // Seek until the first summary record using the file record's fward pointer.
     // Record numbers start from 1 not 0 so we subtract 1 to get to the correct record.
-    lseek(fd, (record.file.fward - 1) * record_length, SEEK_SET);
-    read(fd, record.buf, record_length);
+    lseek(fd, (record->file.fward - 1) * RECORD_LENGTH, SEEK_SET);
+    read(fd, record->buf, RECORD_LENGTH);
 
 	// We are at the first summary block, validate
-	if ((int64_t)record.buf[8] != 0) {
+    if ((int64_t)record->buf[8] != 0) {
         fprintf(stderr, "Error parsing DAF/SPL file. Cannot find summary block.\n");
 		close(fd);
         return NULL; 
@@ -132,8 +399,8 @@ struct spk_s * assist_spk_init(const char *path) {
 	// okay, let's go
 	struct spk_s* pl = calloc(1, sizeof(struct spk_s));
     while (1){ // Loop over records 
-        for (int b = 0; b < (int)record.summary.nsum; b++) { // Loop over summaries
-            struct sum_s* sum = &record.summary.s[b]; // get current summary
+        for (int b = 0; b < (int)record->summary.nsum; b++) { // Loop over summaries
+            struct sum_s* sum = &record->summary.s[b]; // get current summary
             
             // Index in our arrays for current target
             int m = pl->num - 1;
@@ -152,6 +419,8 @@ struct spk_s * assist_spk_init(const char *path) {
                 pl->targets[m].one = calloc(32768, sizeof(int));
                 pl->targets[m].two = calloc(32768, sizeof(int));
                 pl->targets[m].ind = 0;
+                // Set default of mass to 0
+                pl->targets[m].mass = 0;
                 pl->num++;
             }
 
@@ -163,14 +432,14 @@ struct spk_s * assist_spk_init(const char *path) {
         }
 
         // Location of next record
-        long n = (long)record.summary.next - 1;
+        long n = (long)record->summary.next - 1;
         if (n<0){
             // this is already the last record.
             break;
         }else{
             // Find and read next record
-            lseek(fd, n * record_length, SEEK_SET);
-            read(fd, record.buf, record_length);
+            lseek(fd, n * RECORD_LENGTH, SEEK_SET);
+            read(fd, record->buf, RECORD_LENGTH);
         }
     }
 
@@ -279,3 +548,127 @@ enum ASSIST_STATUS assist_spk_calc(struct spk_s *pl, double jde, double rel, int
 	return ASSIST_SUCCESS;
 }
 
+struct spk_target* assist_spk_find_target(struct spk_s *pl, int code) {
+    for (int i = 0; i < pl->num; i++) {
+        if (pl->targets[i].code == code) {
+            return &(pl->targets[i]);
+        }
+    }
+    return NULL;
+}
+
+struct mpos_s assist_spk_target_pos(struct spk_s *pl, struct spk_target* target, double jde, double rel)
+{
+    int n, b, p, P, R;
+    double T[32];
+    double S[32];
+    double U[32];
+    double *val, z;
+    struct mpos_s pos = {0};
+
+    // find location of 'directory' describing the data records
+    n = (int)((jde + rel - target->beg) / target->res);
+    val = (double *)pl->map + target->two[n] - 1;
+
+    // record size and number of coefficients per coordinate
+    R = (int)val[-1];
+    P = (R - 2) / 3; // must be < 32 !!
+
+    // pick out the precise record
+    b = (int)(((jde - _jul(val[-3])) + rel) / (val[-2] / 86400.0));
+    val = (double *)pl->map + (target->one[n] - 1) + b * R;
+
+    // scale to interpolation units
+    z = ((jde - _jul(val[0])) + rel) / (val[1] / 86400.0);
+
+    // Calculate the scaling factor 'c'
+    double c = 1.0 / val[1];
+
+    // set up Chebyshev polynomials
+    T[0] = 1.0; T[1] = z;
+    S[0] = 0.0; S[1] = 1.0;
+    U[0] = 0.0; U[1] = 0.0; U[2] = 4.0;
+
+    for (p = 2; p < P; p++) {
+		T[p] = 2.0 * z * T[p-1] - T[p-2];
+        S[p] = 2.0 * z * S[p-1] + 2.0 * T[p-1] - S[p-2];
+	}
+    for (p = 3; p < P; p++) {
+        U[p] = 2.0 * z * U[p-1] + 4.0 * S[p-1] - U[p-2];
+    }
+
+
+    for (n = 0; n < 3; n++) {
+        b = 2 + n * P;
+        pos.u[n] = pos.v[n] = pos.w[n] = 0.0;
+
+        // sum interpolation stuff
+        for (p = 0; p < P; p++) {
+            double truncated_val = truncate_double(val[b + p], 40);
+            pos.u[n] += truncated_val * T[p];
+            pos.v[n] += truncated_val * S[p] * c;
+            pos.w[n] += truncated_val * U[p] * c * c;
+        }
+    }
+
+    return pos;
+}
+
+
+// Calculate the position and velocity of planets from DE440 SPK file
+enum ASSIST_STATUS assist_spk_calc_planets(struct assist_ephem* ephem, double jde, double rel, int code, double* GM, double* out_x, double* out_y, double* out_z, double* out_vx, double* out_vy, double* out_vz, double* out_ax, double* out_ay, double* out_az)
+{
+
+    struct spk_s* pl = ephem->spk_planets;
+
+    struct spk_target* target = assist_spk_find_target(pl, code);
+
+    if (target == NULL) {
+        return(ASSIST_ERROR_NEPHEM);
+    }
+
+    if (jde + rel < target->beg || jde + rel > target->end){
+        return ASSIST_ERROR_COVERAGE;
+    }
+
+    *GM = target->mass; // Note mass constants defined in DE440/441 ephemeris files. If not found mass of 0 is used.
+
+    struct mpos_s pos = assist_spk_target_pos(pl, target, jde, rel);
+
+    // Earth and Moon must be translated from EMB to SSB frame
+    if (code == 301 || code == 399) {
+        struct spk_target* emb = assist_spk_find_target(pl, 3);
+        struct mpos_s emb_pos = assist_spk_target_pos(pl, emb, jde, rel);
+
+        for (int i = 0; i < 3; i++) {
+            pos.u[i] += emb_pos.u[i];
+            pos.v[i] += emb_pos.v[i];
+            pos.w[i] += emb_pos.w[i];
+        }
+
+    }
+
+    
+
+    // Convert to AU and AU/day
+    const double au = assist_get_constant(ephem, "AU");
+    const double seconds_per_day = 86400.;
+
+    for (int i = 0; i < 3; i++) {
+        pos.u[i] /= au;
+        pos.v[i] /= au / seconds_per_day;
+        pos.w[i] /= au / (seconds_per_day * seconds_per_day);
+    }
+
+    *out_x = pos.u[0];
+    *out_y = pos.u[1];
+    *out_z = pos.u[2];
+    *out_vx = pos.v[0];
+    *out_vy = pos.v[1];
+    *out_vz = pos.v[2];
+    *out_ax = pos.w[0];
+    *out_ay = pos.w[1];
+    *out_az = pos.w[2];
+
+    return ASSIST_SUCCESS;
+}

--- a/src/spk.h
+++ b/src/spk.h
@@ -10,6 +10,9 @@
 
 #include "assist.h"
 
+#define RECORD_LENGTH 1024
+#define MAX_COMMENT_LENGTH 1000000
+
 struct mpos_s {
 	double u[3];
 	double v[3];
@@ -17,7 +20,33 @@ struct mpos_s {
 	double jde;
 };
 
+struct spk_constants {
+    double AU;                     // definition of AU
+    double EMRAT;                     // Earth/Moon mass ratio
+    double J2E;                     // Other constant names follow JPL
+    double J3E;
+    double J4E;
+    double J2SUN;
+    double RE;
+    double CLIGHT;
+    double ASUN;
+};
 
+struct mass_data {
+    char **names;
+    double *values;
+    int count;
+};
+
+// Represents global values of constants and masses
+// fetched from the comments of an SPK file (used with DE440)
+struct spk_global {
+    struct spk_constants con;
+    struct mass_data masses;
+
+};
+
+// Represents available data for a target in a SPK file
 struct spk_target {
     int code;       // Target code
     int cen;     // Centre target
@@ -31,6 +60,7 @@ struct spk_target {
 
 };
 
+// Represents a collection of targets in an SPK file
 struct spk_s {
     struct spk_target* targets;
 	int num;			// number of targets
@@ -39,10 +69,52 @@ struct spk_s {
 	size_t len;			// map length
 };
 
+    // Format for one summary
+struct sum_s {
+    double beg;        // begin epoch, seconds since J2000.0
+    double end;        // ending epoch
+    int tar;        // target code
+    int cen;        // centre code (10 = sun)
+    int ref;        // reference frame (1 = J2000.0)
+    int ver;        // type of ephemeris (2 = chebyshev)
+    int one;        // initial array address
+    int two;        // final array address
+};
+
+// File is split into records. We read one record at a time.
+union record_t {
+    char buf[RECORD_LENGTH];
+    struct {
+        double next;    // The record number of the next summary record in the file. Zero if this is the final summary record.
+        double prev;    // The record number of the previous summary record in the file. Zero if this is the initial summary record.
+        double nsum;    // Number of summaries in this record
+        struct sum_s s[25]; // Summaries (25 is the maximum)
+    } summary;          // Summary record
+    // See: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/daf.html#The%20File%20Record
+    struct {
+        char locidw[8]; // An identification word
+        int nd;         // The number of double precision components in each array summary.
+        int ni;         // The number of integer components in each array summary.
+        char locifn[60];// The internal name or description of the array file.
+        int fward;      // The record number of the initial summary record in the file.
+        int bward;      // The record number of the final summary record in the file.
+        int free;        // Next available free record
+    } file;             // File record
+};
+
+
+
+
 
 int assist_spk_free(struct spk_s *pl);
+int assist_free_spk_constants(struct spk_global *sg);
 struct spk_s * assist_spk_init(const char *path);
+union record_t * assist_load_spk_file_record(int fd);
+struct spk_global * assist_load_spk_constants(const char *path);
+void parse_comments(int fd, int first_summary_record, char **comments);
+void assist_spk_join_masses(struct spk_s *sp, struct spk_global *sg);
 enum ASSIST_STATUS assist_spk_calc(struct spk_s *pl, double jde, double rel, int m, double* GM, double* x, double* y, double* z);
+enum ASSIST_STATUS assist_spk_calc_planets(struct assist_ephem* ephem, double jde, double rel, int m, double* GM, double* x, double* y, double* z, double* vx, double* vy, double* vz, double* ax, double* ay, double* az);
 
 #endif // _SPK_H
 

--- a/unit_tests/5303_Ceres_bsp/Makefile
+++ b/unit_tests/5303_Ceres_bsp/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/unit_tests/5303_Ceres_bsp/problem.c
+++ b/unit_tests/5303_Ceres_bsp/problem.c
@@ -1,0 +1,75 @@
+/**
+ * A unit test fir tge 5303-Ceres encounter.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "rebound.h"
+#include "assist.h"
+
+int main(int argc, char* argv[]){
+
+    struct assist_ephem* ephem = assist_ephem_create(
+            "../../data/de440.bsp",
+            "../../data/sb441-n16.bsp");
+    if (ephem == NULL){
+        fprintf(stderr,"Error initializing assist_ephem.\n");
+        exit(1);
+    }
+    
+    struct reb_simulation* r = reb_simulation_create();
+    struct assist_extras* ax = assist_attach(r, ephem);
+    r->t = 2449718.50 - ephem->jd_ref;
+    
+    double au2meter = 149597870700;
+
+    // Decide whether to include Harmonics in this calculation
+    // ax->forces ^= ASSIST_FORCE_EARTH_HARMONICS;
+    // ax->forces ^= ASSIST_FORCE_SUN_HARMONICS;
+
+    // Decide whether to include GR of planets or not
+    ax->gr_eih_sources = ASSIST_BODY_NPLANETS;
+
+    // Initial conditions of asteroid (5303) Parijskij
+    reb_simulation_add_fmt(r, "x y z vx vy vz",
+        -2.232847879711731E+00, 1.574146331186095E+00, 8.329414259670296E-01,
+        -6.247432571575564E-03, -7.431073424167182E-03, -3.231725223736132E-03);
+   
+    reb_simulation_integrate(r, 2453371.5 - ephem->jd_ref);
+   
+    // Final data from NASA Horizons
+    reb_simulation_add_fmt(r, "x y z vx vy vz",
+            -2.656522667009432E+00, 8.168437454347069E-01, 4.947270505430544E-01,
+            -3.333217972311964E-03, -8.880226801086633E-03, -4.036456444328579E-03);
+
+    // Final data from JPL Small body code
+    struct reb_particle sun = assist_get_particle(ephem, 0, r->t);
+    reb_simulation_add_fmt(r, "x y z",
+        -398052983.0882521/au2meter*1e3+sun.x, 
+        122233037.4686653/au2meter*1e3+sun.y, 
+        74042102.86177272/au2meter*1e3+sun.z);
+    
+    {
+        double diff_x = fabs(r->particles[0].x-r->particles[1].x)*au2meter;
+        double diff_y = fabs(r->particles[0].y-r->particles[1].y)*au2meter;
+        double diff_z = fabs(r->particles[0].z-r->particles[1].z)*au2meter;
+        double diff = sqrt(diff_x*diff_x + diff_y*diff_y + diff_z*diff_z);
+        double tolerance = 501;// meter
+        printf("diff to Horizons %fm\n",diff);
+        assert(diff < tolerance); 
+    }
+    {
+        double diff_x = fabs(r->particles[0].x-r->particles[2].x)*au2meter;
+        double diff_y = fabs(r->particles[0].y-r->particles[2].y)*au2meter;
+        double diff_z = fabs(r->particles[0].z-r->particles[2].z)*au2meter;
+        double diff = sqrt(diff_x*diff_x + diff_y*diff_y + diff_z*diff_z);
+        double tolerance = 500;// meter
+        printf("diff to JPL Small Body code %fm\n",diff);
+        assert(diff < tolerance); 
+    }
+        
+    assist_free(ax);
+    assist_ephem_free(ephem);
+    reb_simulation_free(r);
+}
+

--- a/unit_tests/apophis_bsp/Makefile
+++ b/unit_tests/apophis_bsp/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/unit_tests/apophis_bsp/problem.c
+++ b/unit_tests/apophis_bsp/problem.c
@@ -1,0 +1,80 @@
+/**
+ * A unit test integrating the asteroid Apophis.
+ * The integration includes non-gravitational forces.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "rebound.h"
+#include "assist.h"
+
+int main(int argc, char* argv[]){
+
+    struct assist_ephem* ephem = assist_ephem_create(
+            "../../data/de440.bsp",
+            "../../data/sb441-n16.bsp");
+    if (ephem == NULL){
+        fprintf(stderr,"Error initializing assist_ephem.\n");
+        exit(1);
+    }
+    
+    struct reb_simulation* r = reb_simulation_create();
+    struct assist_extras* ax = assist_attach(r, ephem);
+
+    // Turn on GR from all planets
+    ax->gr_eih_sources = ASSIST_BODY_NPLANETS;
+
+    double t_initial = 2.4621385359989386E+06 - ephem->jd_ref;
+    r->t = t_initial;
+
+    // Initial data from JPL small body code
+    struct reb_particle p_initial = {
+                    .x = -5.5946538550488512E-01, 
+                    .y =  8.5647564757574512E-01, 
+                    .z =  3.0415066217102493E-01,
+                    .vx= -1.3818324735921638E-02, 
+                    .vy= -6.0088275597939191E-03, 
+                    .vz= -2.5805044631309632E-03};
+    
+    // Move from heliocentric to barycentric frame
+    struct reb_particle sun_initial = assist_get_particle(ephem, 0, t_initial);
+    reb_particle_iadd(&p_initial, &sun_initial);
+
+    // Add particle to simulation
+    reb_simulation_add(r, p_initial);
+
+    // Define non-gravitational parameters A1, A2, A3
+    double params[] = {4.999999873689E-13, -2.901085508711E-14, 0.0}; 
+    ax->particle_params = params;
+    
+    // Do the actual integration   
+    r->ri_ias15.min_dt = 0.001; // in days (prevent timestep getting very small during encounter)
+    double t_final = 2.4625030372426095E+06 -ephem->jd_ref; // 1 year later
+    reb_simulation_integrate(r, t_final);
+
+    // Final data from JPL small body code
+    struct reb_particle p_final = {
+                    .x =  1.7028330901729331E-02,
+                    .y =  1.2193934090901304E+00,
+                    .z =  4.7823589236374386E-01,
+                    .vx= -1.3536187639388663E-02,
+                    .vy=  5.3200999989786943E-04,
+                    .vz= -1.6648346717629861E-05};
+
+    // Move from heliocentric to barycentric frame
+    struct reb_particle sun_final = assist_get_particle(ephem, 0, t_final);
+    reb_particle_iadd(&p_final, &sun_final);
+    
+    // Calculate difference
+    double au2meter = 149597870700;
+    double diff = reb_particle_distance(&p_final, &r->particles[0]) * au2meter; // in meter
+
+    // Ensure accuracy is better than 250m
+    fprintf(stderr,"diff to JPL Small Body code %fm\n",diff);
+    assert(diff < 200); 
+
+    assist_free(ax);
+    assist_ephem_free(ephem);
+    reb_simulation_free(r);
+}
+

--- a/unit_tests/de440_compare_constants/Makefile
+++ b/unit_tests/de440_compare_constants/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/unit_tests/de440_compare_constants/problem.c
+++ b/unit_tests/de440_compare_constants/problem.c
@@ -1,0 +1,59 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <math.h>
+#include "assist.h"
+#include "forces.h"
+
+/*
+* Compare the planet ephemeris for the ascii/binary and bsp versions of DE440.
+*
+* Note that it appears the actual coefficient values in the files vary
+* in the range of 1-2 units in the last decimal place.
+* 
+*/
+
+
+int main(int argc, char *argv[]) {
+
+    char *linux_binary_path = "../../data/linux_p1550p2650.440";
+    char *bsp_path = "../../data/de440.bsp";
+
+    struct assist_ephem *binary_ephem = assist_ephem_create(linux_binary_path, NULL);
+    if (!binary_ephem) {
+        fprintf(stderr, "Failed to initialize ephemeris data.\n");
+        return EXIT_FAILURE;
+    }
+
+    struct assist_ephem *bsp_ephem = assist_ephem_create(bsp_path, NULL);
+    if (!bsp_ephem) {
+        fprintf(stderr, "Failed to initialize ephemeris data.\n");
+        return EXIT_FAILURE;
+    }
+
+    const char *constant_names[] = {
+        "AU",
+        "EMRAT",
+        "J2E",
+        "J3E",
+        "J4E",
+        "J2SUN",
+        "RE",
+        "CLIGHT",
+        "ASUN"
+    };
+
+    const double threshold = 1e-20;
+
+    for (int i = 0; i < 9; i++) {
+        double binary_constant = assist_get_constant(binary_ephem, constant_names[i]);
+        double bsp_constant = assist_get_constant(bsp_ephem, constant_names[i]);
+        printf("%s: %f %f\n", constant_names[i], binary_constant, bsp_constant);
+        assert(fabs(binary_constant - bsp_constant) < threshold);
+    };
+
+    assist_ephem_free(binary_ephem);
+    assist_ephem_free(bsp_ephem);
+  
+    return EXIT_SUCCESS;
+}

--- a/unit_tests/de440_compare_ephem/Makefile
+++ b/unit_tests/de440_compare_ephem/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/unit_tests/de440_compare_ephem/problem.c
+++ b/unit_tests/de440_compare_ephem/problem.c
@@ -1,0 +1,79 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <math.h>
+#include "assist.h"
+#include "forces.h"
+
+/*
+* Compare the planet ephemeris for the ascii/binary and bsp versions of DE440.
+*
+* Note that it appears the actual coefficient values in the files vary
+* in the range of 1-2 units in the last decimal place.
+* 
+*/
+
+
+int main(int argc, char *argv[]) {
+
+    char *linux_binary_path = "../../data/linux_p1550p2650.440";
+    char *bsp_path = "../../data/de440.bsp";
+
+    struct assist_ephem *binary_ephem = assist_ephem_create(linux_binary_path, NULL);
+    if (!binary_ephem) {
+        fprintf(stderr, "Failed to initialize ephemeris data.\n");
+        return EXIT_FAILURE;
+    }
+
+    struct assist_ephem *bsp_ephem = assist_ephem_create(bsp_path, NULL);
+    if (!bsp_ephem) {
+        fprintf(stderr, "Failed to initialize ephemeris data.\n");
+        return EXIT_FAILURE;
+    }
+
+    // Call assist_all_ephem for both versions of the ephemeris data
+    // and compare the results
+    double times[] = {0.0, 100.0, 1000.0, 10000.0};
+    for (int body = 0; body < 11; body++) {
+
+        printf("body: %d\n", body);
+        for (int i = 0; i < 4; i++) {
+            double t = times[i];
+
+            double GMa, xa, ya, za, vxa, vya, vza, axa, aya, aza;
+            int ret = assist_all_ephem(binary_ephem, NULL, body, t, &GMa, &xa, &ya, &za, &vxa, &vya, &vza, &axa, &aya, &aza);
+            if (ret != 0) {
+                printf("ret: %d\n", ret);
+                fprintf(stderr, "Failed to get ephemeris data from binary file.\n");
+                return EXIT_FAILURE;
+            }
+
+            double GMb, xb, yb, zb, vxb, vyb, vzb, axb, ayb, azb;
+            ret = assist_all_ephem(bsp_ephem, NULL, body, t, &GMb, &xb, &yb, &zb, &vxb, &vyb, &vzb, &axb, &ayb, &azb);
+            if (ret != 0) {
+                fprintf(stderr, "Failed to get ephemeris data from bsp file.\n");
+                return EXIT_FAILURE;
+            }
+
+            // Assert differences are below a certain threshold
+            double threshold = 0.0;
+            double accumulated_diff = 0.0;
+            double comparisons[] = {GMb, xb, yb, zb, vxb, vyb, vzb, axb, ayb, azb,
+                                    GMa, xa, ya, za, vxa, vya, vza, axa, aya, aza};
+            for (int j = 0; j < 10; j++) {
+                double diff = fabs(comparisons[j] - comparisons[j + 10]);
+                if (diff > threshold) {
+                    accumulated_diff += diff;
+                    // // throw error
+                    // return EXIT_FAILURE;
+                }
+            }
+            printf("accumulated_diff: %.17e\n", accumulated_diff);
+        }
+    }
+
+    assist_ephem_free(binary_ephem);
+    assist_ephem_free(bsp_ephem);
+  
+    return EXIT_SUCCESS;
+}

--- a/unit_tests/ephem_init/Makefile
+++ b/unit_tests/ephem_init/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/unit_tests/ephem_init/problem.c
+++ b/unit_tests/ephem_init/problem.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "spk.h"
+
+/*
+* Test loading combinations of different ephem and spk files.
+*/
+
+
+int main(int argc, char *argv[]) {
+    if (argc != 3) {
+        fprintf(stderr, "Usage: %s <path to planets .bsp file> <path to asteroids .bsp file>\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    char *planets_path = argv[1];
+    char *asteroids_path = argv[2];
+    struct assist_ephem *ephem = assist_ephem_create(planets_path, asteroids_path);
+    if (!ephem) {
+        fprintf(stderr, "Failed to initialize ephemeris data.\n");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/unit_tests/spk_init/Makefile
+++ b/unit_tests/spk_init/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/unit_tests/spk_init/problem.c
+++ b/unit_tests/spk_init/problem.c
@@ -1,0 +1,65 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "spk.h"
+
+int main(int argc, char *argv[]) {
+    char *planet_path = "../../data/de440.bsp";
+    char *asteroid_path = "../../data/sb441-n16.bsp";
+
+    struct spk_s *planet_spk = assist_spk_init(planet_path);
+    if (!planet_spk) {
+        fprintf(stderr, "Failed to initialize SPK data.\n");
+        return EXIT_FAILURE;
+    }
+
+    // Assert that there are 14 targets in the planet SPK data
+    // 1 : Mercury
+    // 2 : Venus
+    // 3 : Earth-Moon barycenter
+    // 4 : Mars
+    // 5 : Jupiter
+    // 6 : Saturn
+    // 7 : Uranus
+    // 8 : Neptune
+    // 9 : Pluto
+    // 10 : Sun
+    // 301 : Moon
+    // 399 : Earth
+    // 199 : Mercury (Mercury barycenter)
+    // 299 : Venus (Venus barycenter)
+
+    assert(planet_spk->num == 14);
+    int counted_targets = 0;
+
+    for (int i = 0; i < 16; i++) {
+        // Assuming a valid target has a non-zero code, adjust the condition as necessary
+        if (planet_spk->targets[i].code != 0) {
+            counted_targets++;
+        }
+    }
+    assert(counted_targets == 14);
+
+    assist_spk_free(planet_spk);
+
+    struct spk_s *asteroid_spk = assist_spk_init(asteroid_path);
+    if (!asteroid_spk) {
+        fprintf(stderr, "Failed to initialize SPK data.\n");
+        return EXIT_FAILURE;
+    }
+
+    // Assert that there are 16 targets in the asteroid SPK data
+    assert(asteroid_spk->num == 16);
+    counted_targets = 0;
+    
+    for (int i = 0; i < 20; i++) {
+        // Assuming a valid target has a non-zero code, adjust the condition as necessary
+        if (asteroid_spk->targets[i].code != 0) {
+            counted_targets++;
+        }
+    }
+
+    assist_spk_free(asteroid_spk);  
+
+    return EXIT_SUCCESS;
+}

--- a/unit_tests/spk_join_masses/Makefile
+++ b/unit_tests/spk_join_masses/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/unit_tests/spk_join_masses/problem.c
+++ b/unit_tests/spk_join_masses/problem.c
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "spk.h"
+
+
+void assert_populated_masses(struct spk_s *spk_data) {
+    if (!spk_data) {
+        printf("SPK data is NULL.\n");
+        return;
+    }
+
+    for (int i = 0; i < spk_data->num; i++) {
+        struct spk_target *target = &spk_data->targets[i];
+        // We do not calculate mass for mercury and venus barycenters
+        if (target->code != 199 && target->code != 299) {
+            // Assert that the masses are not zero
+            assert(target->mass != 0.0);
+        }
+    }
+}
+
+
+int main(int argc, char *argv[]) {
+
+    const char *planets_path = "../../data/de440.bsp";
+    const char *asteroids_path = "../../data/sb441-n16.bsp";
+
+    struct spk_global *sg = assist_load_spk_constants(planets_path);
+    if (!sg) {
+        fprintf(stderr, "Failed to initialize SPK data.\n");
+        return EXIT_FAILURE;
+    }
+    struct spk_s *planet_data = assist_spk_init(planets_path);
+    if (!planet_data) {
+        fprintf(stderr, "Failed to initialize SPK data.\n");
+        return EXIT_FAILURE;
+    }
+
+    assist_spk_join_masses(planet_data, sg);
+    assert_populated_masses(planet_data);
+
+    struct spk_s *asteroid_data = assist_spk_init(asteroids_path);
+    if (!asteroid_data) {
+        fprintf(stderr, "Failed to initialize SPK data.\n");
+        return EXIT_FAILURE;
+    }
+
+    assist_spk_join_masses(asteroid_data, sg);
+    assert_populated_masses(asteroid_data);
+
+    assist_spk_free(planet_data);
+    assist_spk_free(asteroid_data);
+
+    assist_free_spk_constants(sg);
+
+    return EXIT_SUCCESS;
+}

--- a/unit_tests/spk_load_constants/Makefile
+++ b/unit_tests/spk_load_constants/Makefile
@@ -1,0 +1,46 @@
+ifndef REB_DIR
+ifneq ($(wildcard ../../../rebound/.*),) # Check for REBOUND in default location
+REB_DIR=../../../rebound
+endif
+ifneq ($(wildcard ../../../../rebound/.*),) # Check for ASSIST being inside REBOUND directory
+REB_DIR=../../../
+endif
+endif
+ifndef REB_DIR # REBOUND is not in default location and REB_DIR is not set
+    $(error ASSIST not in the same directory as REBOUND.  To use a custom location, you Must set the REB_DIR environment variable for the path to your rebound directory, e.g., export REB_DIR=/Users/dtamayo/rebound.)
+endif
+PROBLEMDIR=$(shell basename `dirname \`pwd\``)"/"$(shell basename `pwd`)
+
+include $(REB_DIR)/src/Makefile.defs
+
+ASSIST_DIR=../../
+
+all: librebound.so libassist.so
+	@echo ""
+	@echo "Compiling problem file ..."
+	$(CC) -I$(ASSIST_DIR)/src/ -I$(REB_DIR)/src/ -Wl,-rpath,./ $(OPT) $(PREDEF) problem.c -L. -lassist -lrebound $(LIB) -o rebound
+	@echo ""
+	@echo "Problem file compiled successfully."
+
+librebound.so:
+	@echo "Compiling shared library librebound.so ..."
+	$(MAKE) -C $(REB_DIR)/src/
+	@echo "Creating link for shared library librebound.so ..."
+	@-rm -f librebound.so
+	@ln -s $(REB_DIR)/src/librebound.so .
+
+libassist.so: librebound.so $(ASSIST_DIR)/src/*.h $(ASSIST_DIR)/src/*.c
+	@echo "Compiling shared library libassist.so ..."
+	$(MAKE) -C $(ASSIST_DIR)/src/
+	@-rm -f libassist.so
+	@ln -s $(ASSIST_DIR)/src/libassist.so .
+
+clean:
+	@echo "Cleaning up shared library librebound.so ..."
+	@-rm -f librebound.so
+	$(MAKE) -C $(REB_DIR)/src/ clean
+	@echo "Cleaning up shared library libassist.so ..."
+	@-rm -f libassist.so
+	$(MAKE) -C $(ASSIST_DIR)/src/ clean
+	@echo "Cleaning up local directory ..."
+	@-rm -vf rebound

--- a/unit_tests/spk_load_constants/problem.c
+++ b/unit_tests/spk_load_constants/problem.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "spk.h"
+
+
+void assert_constants_exist(struct spk_global *sg) {
+    struct spk_constants *sc = &sg->con;
+    assert(sc->AU != 0.0);
+    assert(sc->EMRAT != 0.0);
+    assert(sc->J2E != 0.0);
+    assert(sc->J3E != 0.0);
+    assert(sc->J4E != 0.0);
+    assert(sc->J2SUN != 0.0);
+    assert(sc->RE != 0.0);
+    assert(sc->CLIGHT != 0.0);
+    assert(sc->ASUN != 0.0);
+    assert(sg->masses.count = 420);
+    for (int i = 0; i < sg->masses.count; i++) {
+        assert(sg->masses.names[i] != NULL);
+        assert(sg->masses.values[i] != 0.0);
+    }
+}
+
+int main(int argc, char *argv[]) {
+
+    const char *planets_path = "../../data/de440.bsp";
+
+    struct spk_global *sg = assist_load_spk_constants(planets_path);
+    if (!sg) {
+        fprintf(stderr, "Failed to initialize SPK data.\n");
+        return EXIT_FAILURE;
+    }
+
+    assert_constants_exist(sg);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
A pull request to address https://github.com/matthewholman/assist/issues/106 , adding support for the spice kernel version of DE440.

# Overview of Changes

* The ephem struct now contains two new optional pointers to the spk_s struct pointed to the planets file and a new spk_global struct that contains the constants and masses loaded from DE440.bsp
* When calculating ephemeris, forces.c will conditionally use the `assist_spk_calc_planets` functions for the planets when the spk planets file is detected, otherwise using the existing `assist_jpl_calc`.
* `assist_spk_calc_planets` differs from `assist_spk_calc` mainly in that it calculates velocity and acceleration. It also maps the assist planet indices to their spk target codes, rather than directly using an index.
* When using DE440.bsp, there are new functions for joining the mass data to the targets in each file
* There is a new `assist_get_constant` function that will conditionally get the constant from whichever of the two files the data was initialized from.
* Introducing a `truncate_double` function, to truncate the significand. This is explained in "Differences in Coefficient Values between ASCII and SPICE", below.

# Verification

I have added unit tests for initializing the spk files, loading the constant data, and joining masses to the targets from the loaded constant data.

I have also added a couple of identical unit tests for Apophis and Ceres to make sure tolerances were kept between the two implementations. I manually checked most of the other unit tests as well, but didn't want to duplicate each one until I received opinions on how to structure the unit tests. I could update them all to be parameterized from command line arguments if that seems better.

## Earth & Moon Residuals
There is still a disagreement on order 1e-15 AU for the Earth and Moon ephemeris. This difference causes the SPICE and ASCII implementations to perform differently. In particular with the Apophis unit test, the SPICE implementation has a delta from JPL small body of ~47m, whereas the ASCII implementation is ~93m. 

The ASCII file contains data for Moon (Earth geocenter frame) and EMB (SSB frame). The SPICE file contains data for Moon (EMB frame), Earth (EMB frame) and EMB (SSB frame). As far as I can tell, this means I cannot use an identical implementation, as the lunar frames are different. For the SPICE implementation, I believe I should be able to simply add the vectors (e.g. `Moon (SSB) = EMB (SSB) + Moon (EMB)` ).

I have verified that the following values are identical and not the source of the disagreement:
- Earth and Moon masses
- EMB (SSB) ephemeris
- Earth-Moon mass ratio

I'd love suggestions on how to get these number into total agreement. In the case of the ASCII file, Is it possible that using the Earth-Moon mass ratio to calculate the Moon (SSB) and Earth (SSB) vectors is not as accurate?


# Differences in Coefficient Values between ASCII and SPICE
This is a bit of a separate topic, and potentially a big one. After a lot of digging, I believe that there is a difference in the double values loaded directly from the files into the memory maps. These differences are quite small and likely below the usable precision of the coefficients. However, the residuals are enough to affect the results.

Here is a table of coefficients for the Sun at J2000. The left column is the value extracted from the plaintext readable ASCII version. The middle column is the residual of the binary to its ASCII version (they are identical, as expected). The right column is the residual of the SPICE kernel to the ASCII file.

```md
| ascp01950.440                  | linux_p1550p2650.440         | de440.bsp                    |
|--------------------------------|------------------------------|------------------------------|
| -1.06808883301021694e+06       | 0.0                          | 2.328306e-10                 |
| 6.43167333734120621e+03        | 0.0                          | 0.0                          |
| 2.01221489458825502e+01        | 0.0                          | 3.552714e-15                 |
| -5.05048275205624633e-02       | 0.0                          | 0.0                          |
| 3.66293150750863095e-03        | 0.0                          | 4.336809e-19                 |
| 6.87050023573884547e-05        | 0.0                          | 0.0                          |
| 1.04739050584889000e-07        | 0.0                          | -3.970467e-23                |
| -9.62554122375419690e-08       | 0.0                          | 0.0                          |
| 1.41137100915376000e-08        | 0.0                          | -4.963084e-24                |
| -1.97668373379263398e-09       | 0.0                          | 0.0                          |
| 5.86673164381741959e-11        | 0.0                          | 0.0                          |
| -3.95512524278347497e+05       | 0.0                          | 0.0                          |
| -8.09283375554062332e+03       | 0.0                          | 0.0                          |
| 1.80149861187318088e+01        | 0.0                          | -3.552714e-15                |
| -8.42604441851760450e-02       | 0.0                          | 0.0                          |
| 1.13093369546329297e-04        | 0.0                          | 2.710505e-20                 |
| 5.03867718918667103e-05        | 0.0                          | 0.0                          |
| 5.93445081607049939e-06        | 0.0                          | 0.0                          |
| -9.87525623150012930e-08       | 0.0                          | 0.0                          |
| 2.33800156279631085e-08        | 0.0                          | 0.0                          |
| 1.59321012060578690e-10        | 0.0                          | 0.0                          |
| 1.56840618138031596e-11        | 0.0                          | 3.231174e-27                 |
| -1.37831006431904796e+05       | 0.0                          | -2.910383e-11                |
| -3.63161643242317587e+03       | 0.0                          | -4.547474e-13                |
| 7.26636726809482969e+00        | 0.0                          | 0.0                          |
| -4.21481400983880414e-02       | 0.0                          | 0.0                          |
| -9.53718391925790533e-05       | 0.0                          | 0.0                          |
| 1.45128782935172393e-05        | 0.0                          | 0.0                          |
| 3.09572793936219392e-06        | 0.0                          | 4.235165e-22                 |
| -4.05084185115523090e-08       | 0.0                          | 0.0                          |
| 1.10153616306458299e-08        | 0.0                          | -1.654361e-24                |
| 2.91662353472744123e-10        | 0.0                          | -5.169879e-26                |
| 1.67388559412173401e-12        | 0.0                          | -4.038968e-28                |
```

I wanted to make sure that the disagreement didn't have to do with the way that ASSIST was memory mapping the files. I used Brandon Rhode's `jplephem` to separately load the coefficient values from the SPICE file and it is reading them identically to the ASSIST implementation.

### Precision

You may notice that the residuals are proportional the value itself. This could be explained by one or two units of precision difference for the float significand in the two files. I couldn't locate how precise they ought to be (e.g., are the real values using the full precision offered by the double). Perhaps someone more familiar with the specification knows.

### Amelioration

I was able to get identical behavior from both implementations by using a `truncate_double` function. This function masks the bits to a desired precision of the float significand. After manually exploring different levels of truncation, I found that masking down to 40 bits eliminated the difference between the coefficient values. Interestingly, adding this truncation also appears to put the unit tests in closer agreement with the JPL Small Body Code, at least for the Apophis and Ceres unit tests. Truncating further causes them to agree less with JPL Small Body Code, as one might expect.

While the truncation offers a solution for agreement between SPICE and ASCII, I am concerned and curious about why it makes them agree more with Horizons and Small Body. Does this imply that small body, for example, are using truncated or different values than are located in the spice kernels? I don't know, but I want to find out.